### PR TITLE
change the default ssh key name

### DIFF
--- a/node-manager/run-example/config/infrastructure.jsonc
+++ b/node-manager/run-example/config/infrastructure.jsonc
@@ -2,7 +2,7 @@
 {
     "aws": {
         "ec2_region": "eu-central-1",
-        "ssh_key_name": "ec2:mockfog2:ssh-key",
+        "ssh_key_name": "ec2-mockfog2-ssh-key",
         "agent_port": 3100 // the port on which the node agent provides its services
     },
     // Every machine in this list defines a single remote host setup on AWS EC2.


### PR DESCRIPTION
"ec2:mockfog2:ssh-key" is not a valid file name in macOS. 
Sometimes one needs to access the machine from the local computer 