### PR TITLE
Fixes and more understandable user experience

### DIFF
--- a/node-manager/app.js
+++ b/node-manager/app.js
@@ -54,7 +54,7 @@ if (myArgs[0] in phases) {
         logger.info("Listening for message-based transition events on port " + conf.nmPort)
 
         manager.execute_schedule().then(_ => {
-            logger.info("Orchestration schedlue executed")
+            logger.info("Orchestration schedule executed")
             server.close()
         })
     } else {

--- a/node-manager/lib/data/infrastructure.js
+++ b/node-manager/lib/data/infrastructure.js
@@ -118,9 +118,9 @@ function getOneHopEdges(machine_name, connections) {
     connections.forEach(connection => {
         // could be encoded in either direction (bidirectional)
         if (machine_name === connection.from) {
-            result[connection.to] = connection.delay
+            result[connection.to] = connection.delay == 0 ? 1e-10 : connection.delay
         } else if (machine_name === connection.to) {
-            result[connection.from] = connection.delay
+            result[connection.from] = connection.delay == 0 ? 1e-10 : connection.delay
         }
     })
     return result

--- a/node-manager/lib/stages/03_orchestration/orchestration-manager.js
+++ b/node-manager/lib/stages/03_orchestration/orchestration-manager.js
@@ -173,7 +173,19 @@ function applyConnectionUpdates(infrastructure, connection_updates) {
     for (const connection of connection_updates) {
         // find connection
         let toUpdate = infra.connections.filter(con => con.from === connection.from).filter(con => con.to === connection.to)
-        if (toUpdate.length !== 1) {
+        if (toUpdate.length === 0) {
+            toUpdate = infra.connections.filter(con => con.to === connection.from).filter(con => con.from === connection.to);
+            toUpdate.forEach(element => {
+                const tmp = element.to;
+                element.to = element.from;
+                element.from = tmp;
+            });
+        }
+        if (toUpdate.length === 0) {
+            logger.error(`No connection found which should be updated with ${JSON.stringify(connection)} => skipping`)
+            // TODO add new connection if not found
+            continue
+        } else if (toUpdate.length !== 1) {
             logger.error(`${JSON.stringify(toUpdate)} should be updated with ${JSON.stringify(connection)}, but it is not a single element => skipping`)
             // TODO add new connection if not found
             continue

--- a/node-manager/lib/stages/03_orchestration/orchestration-manager.js
+++ b/node-manager/lib/stages/03_orchestration/orchestration-manager.js
@@ -175,11 +175,6 @@ function applyConnectionUpdates(infrastructure, connection_updates) {
         let toUpdate = infra.connections.filter(con => con.from === connection.from && con.to === connection.to)
         if (toUpdate.length === 0) {
             toUpdate = infra.connections.filter(con => con.to === connection.from && con.from === connection.to);
-            toUpdate.forEach(element => {
-                const tmp = element.to;
-                element.to = element.from;
-                element.from = tmp;
-            });
         }
         if (toUpdate.length === 0) {
             logger.error(`No connection found which should be updated with ${JSON.stringify(connection)} => skipping`)

--- a/node-manager/lib/stages/03_orchestration/orchestration-manager.js
+++ b/node-manager/lib/stages/03_orchestration/orchestration-manager.js
@@ -172,9 +172,9 @@ function applyConnectionUpdates(infrastructure, connection_updates) {
 
     for (const connection of connection_updates) {
         // find connection
-        let toUpdate = infra.connections.filter(con => con.from === connection.from).filter(con => con.to === connection.to)
+        let toUpdate = infra.connections.filter(con => con.from === connection.from && con.to === connection.to)
         if (toUpdate.length === 0) {
-            toUpdate = infra.connections.filter(con => con.to === connection.from).filter(con => con.from === connection.to);
+            toUpdate = infra.connections.filter(con => con.to === connection.from && con.from === connection.to);
             toUpdate.forEach(element => {
                 const tmp = element.to;
                 element.to = element.from;

--- a/node-manager/lib/stages/03_orchestration/tc-evaluator.js
+++ b/node-manager/lib/stages/03_orchestration/tc-evaluator.js
@@ -121,14 +121,14 @@ class TCEvaluator {
     }
 
     _getTBC() {
-        const merged = [].concat.apply(Object.values(this._activeConditions)).flat()
+        const merged = [].concat.apply([], Object.values(this._activeConditions))
         return merged.filter((condition) => {
             return condition.type === "time-based"
         })
     }
 
     _getMBC() {
-        const merged = [].concat.apply(Object.values(this._activeConditions)).flat()
+        const merged = [].concat.apply([], Object.values(this._activeConditions))
         return merged.filter((condition) => {
             return condition.type === "message-based"
         })


### PR DESCRIPTION
- flat() was somehow not supported => use a native method
- a delay of 0 caused errors => added a minor factor
- a connection with swapped "from" and "to" was not considered doing orchestration, but connections are bidirectional => check for both directions